### PR TITLE
fix(bin): Scripts interoperability

### DIFF
--- a/bin/request
+++ b/bin/request
@@ -1,4 +1,4 @@
-#!/usr/bin/env nodejs
+#!/usr/bin/env node
 //
 // export TEXTREE_GIT_DIR=/local.repository.git/
 //

--- a/bin/service
+++ b/bin/service
@@ -1,4 +1,4 @@
-#!/usr/bin/env nodejs
+#!/usr/bin/env node
 
 /**
  ** HTTP entry point of Textree

--- a/bin/textree
+++ b/bin/textree
@@ -1,4 +1,4 @@
-#!/usr/bin/env nodejs
+#!/usr/bin/env node
 
 /**
  ** Textree CLI interface


### PR DESCRIPTION
The upstream name for the Node.js interpreter command is `node`. Thus, modern distributions ship Node.js binary under `/usr/bin/node`; but Debian uses the `nodejs` (because of a namespace collision with `ax25-node`).

Parallely, major Node.js projects use `node` (not `nodejs`), for example [NPM](https://github.com/npm/npm/blob/master/bin/npm-cli.js#L1), [Jade](https://github.com/pugjs/pug-cli/blob/master/index.js#L1), [Gulp](https://github.com/gulpjs/gulp/blob/master/bin/gulp.js#L1)...

This commit changes scripts to use `node` binary instead of `nodejs`, for interoperability reasons.

FWIW, some Debian & Ubuntu users recommend [symlinking `node`](https://github.com/websockets/ws/issues/458) or [installing nodejs-legacy](http://stackoverflow.com/a/21171188).